### PR TITLE
Reverse lookup podcast page from podcast path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,11 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, RiffRaffA
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
-  "ch.qos.logback" %  "logback-classic" % "1.1.7",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.13",
   "com.amazonaws" % "aws-lambda-java-events" % "1.0.0",
   "com.github.melrief" %% "purecsv" % "0.0.6",
+  "com.gu" %% "content-api-client" % "10.15",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 )
 

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -4,4 +4,6 @@ object Config {
 
   val AudioLogsBucketName = "fastly-logs-audio"
 
+  val capiKey = sys.env("CAPI_KEY")
+
 }

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.{ Context, RequestHandler }
 import scala.collection.JavaConverters._
 import com.gu.contentapi.Config.AudioLogsBucketName
 import com.gu.contentapi.models.FastlyLog
-import com.gu.contentapi.services.S3
+import com.gu.contentapi.services.{ PageLookup, S3 }
 import com.gu.contentapi.utils.WriteToFile
 import com.typesafe.scalalogging.StrictLogging
 import scala.io.Source
@@ -26,9 +26,17 @@ class Lambda extends RequestHandler[S3Event, Unit] with StrictLogging {
         FastlyLog(line)
       }
 
-      logger.info(s"DEBUG: I got ${allFastlyLogs.length} to process from logfile ${logObj.getKey}")
+      println(s"DEBUG: I got ${allFastlyLogs.length} to process from logfile")
 
-      // TODO: foreach fastlylog, fill in the podcast page url and send the result to Ophan
+      allFastlyLogs foreach { fastlyLog =>
+        PageLookup.getPagePath("https://audio.guim.co.uk" + fastlyLog.url)
+      }
+
+      println("Done :) -- FYI:")
+      println(s"Cache hits: ${PageLookup.cacheHits}")
+      println(s"Cache misses: ${PageLookup.cacheMisses}")
+
+      // TODO send stuff to Ophan.
     }
 
   }

--- a/src/main/scala/com/gu/contentapi/services/PageLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PageLookup.scala
@@ -46,7 +46,7 @@ object PageLookup extends StrictLogging {
       Await.result(
         makeCapiQuery(filePath) map {
           case SuccessfulQuery(sr) => {
-            sr.results.headOption foreach { content => cache += (filePath -> content.webUrl) }
+            sr.results.headOption foreach { content => cache.put(filePath, content.webUrl) }
             sr.results.headOption map (_.webUrl)
           }
           case FailedQuery(err) => Some(err)

--- a/src/main/scala/com/gu/contentapi/services/PageLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PageLookup.scala
@@ -1,0 +1,58 @@
+package com.gu.contentapi.services
+
+import com.gu.contentapi.client._
+import com.gu.contentapi.client.model.v1.SearchResponse
+import com.gu.contentapi.client.model.SearchQuery
+import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+import com.gu.contentapi.Config.capiKey
+import scala.collection.concurrent.TrieMap
+
+object PageLookup extends StrictLogging {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  sealed trait ResponseFromCapiQuery
+  case class SuccessfulQuery(searchResponse: SearchResponse) extends ResponseFromCapiQuery
+  case class FailedQuery(errorMsg: String) extends ResponseFromCapiQuery
+
+  val client = new GuardianContentClient(capiKey)
+
+  val cache = TrieMap[String, String]()
+  var cacheHits = 0
+  var cacheMisses = 0
+
+  private def makeCapiQuery(filePath: String): Future[ResponseFromCapiQuery] = {
+    val query = SearchQuery().filename(filePath)
+
+    client.getResponse(query) map { searchResponse: SearchResponse =>
+      searchResponse.status match {
+        case "ok" => SuccessfulQuery(searchResponse)
+        case _ => FailedQuery(s"Failed query for filePath: $filePath")
+      }
+    } recover {
+      case GuardianContentApiError(status, msg, _) =>
+        FailedQuery(s"Received unexpected response from CAPI: status $status with message $msg")
+    }
+  }
+
+  def getPagePath(filePath: String): Option[String] = {
+    if (cache contains filePath) {
+      cacheHits += 1
+      cache.get(filePath)
+    } else {
+      cacheMisses += 1
+      Await.result(
+        makeCapiQuery(filePath) map {
+          case SuccessfulQuery(sr) => {
+            sr.results.headOption foreach { content => cache += (filePath -> content.webUrl) }
+            sr.results.headOption map (_.webUrl)
+          }
+          case FailedQuery(err) => Some(err)
+        }, 2.seconds
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This provides the logic to reverse lookup a podcast page given a podcast file path, i.e. going from `podcast123.mp3` to `gu.com/some-podcast.html`.

The requests to CAPI are blocking because this is a Lambda (and also so we don't spam Concierge).

We're providing a rudimentary but quite effective in-memory caching via a mutable `Map`. Although this is far from being perfect (a Lambda times out every 5 minutes) tests show that we have a 70-90% ratio of cache hits, so this is good enough for now.

The `vars` for `cacheHits` and `cacheMisses` are only temporary but I think it's good to have some logging about those values, at lest at the beginning.