### PR TITLE
Get podcast series name from CAPI

### DIFF
--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.{ Context, RequestHandler }
 import scala.collection.JavaConverters._
 import com.gu.contentapi.Config.AudioLogsBucketName
 import com.gu.contentapi.models.FastlyLog
-import com.gu.contentapi.services.{ PageLookup, S3 }
+import com.gu.contentapi.services.{ PodcastLookup, S3 }
 import com.gu.contentapi.utils.WriteToFile
 import com.typesafe.scalalogging.StrictLogging
 import scala.io.Source
@@ -29,12 +29,12 @@ class Lambda extends RequestHandler[S3Event, Unit] with StrictLogging {
       println(s"DEBUG: I got ${allFastlyLogs.length} to process from logfile")
 
       allFastlyLogs foreach { fastlyLog =>
-        PageLookup.getPagePath("https://audio.guim.co.uk" + fastlyLog.url)
+        PodcastLookup.getPodcastInfo("https://audio.guim.co.uk" + fastlyLog.url)
       }
 
       println("Done :) -- FYI:")
-      println(s"Cache hits: ${PageLookup.cacheHits}")
-      println(s"Cache misses: ${PageLookup.cacheMisses}")
+      println(s"Cache hits: ${PodcastLookup.cacheHits}")
+      println(s"Cache misses: ${PodcastLookup.cacheMisses}")
 
       // TODO send stuff to Ophan.
     }

--- a/src/test/scala/com/gu/contentapi/LambdaSpec.scala
+++ b/src/test/scala/com/gu/contentapi/LambdaSpec.scala
@@ -1,7 +1,9 @@
 package com.gu.contentapi
 
 import com.gu.contentapi.models.FastlyLog
+import com.gu.contentapi.services.PodcastLookup
 import org.scalatest.{ FlatSpec, Matchers }
+
 import scala.io.Source
 
 class LambdaSpec extends FlatSpec with Matchers {
@@ -77,5 +79,15 @@ class LambdaSpec extends FlatSpec with Matchers {
     )
     thirdPw should be(pageViews(2))
   }
+
+  // Commented out because we don't want to run CAPI query on TeamCity.
+
+  //  it should "Test the Podcast Lookup function" in {
+  //
+  //    val info = PodcastLookup.getPodcastInfo("https://audio.guim.co.uk/2016/12/19-57926-FW-dec19-2016_mixdown.mp3")
+  //
+  //    info.get.podcastName should be("Football Weekly - The Guardian")
+  //    info.get.webUrl should be("https://www.theguardian.com/football/blog/audio/2016/dec/19/manchester-city-bounce-back-to-leave-wenger-fuming-football-weekly")
+  //  }
 
 }


### PR DESCRIPTION
Info we want to send to Ophan include the pair `(episode id, podcast name)` for each episode, so when we do the reverse lookup from _podcast filename_ to _capi entry_ we also want to get the episode name.