### PR TITLE
Send events to Ophan!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "1.0.0",
   "com.github.melrief" %% "purecsv" % "0.0.6",
   "com.gu" %% "content-api-client" % "10.15",
+  "com.squareup.okhttp3" % "okhttp" % "3.4.1",
+  "net.openhft" % "zero-allocation-hashing" % "0.6",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 )
 

--- a/src/main/scala/com/gu/contentapi/models/Event.scala
+++ b/src/main/scala/com/gu/contentapi/models/Event.scala
@@ -1,0 +1,30 @@
+package com.gu.contentapi.models
+
+import com.gu.contentapi.services.PodcastLookup
+import net.openhft.hashing.LongHashFunction
+
+case class Event(
+  viewId: String,
+  url: String,
+  ipAddress: String,
+  episodeId: String,
+  podcastId: String
+)
+
+object Event {
+
+  def apply(fastlyLog: FastlyLog): Option[Event] = {
+    val fullPathToFile = s"https://audio.guim.co.uk${fastlyLog.url}"
+
+    PodcastLookup.getPodcastInfo(fullPathToFile) map { info =>
+      Event(
+        viewId = LongHashFunction.xx_r39().hashChars(fullPathToFile + fastlyLog.time).toString,
+        url = fullPathToFile,
+        ipAddress = fastlyLog.ipAddress,
+        episodeId = info.episodeId,
+        podcastId = info.podcastId
+      )
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
@@ -21,8 +21,8 @@ object PodcastLookup extends StrictLogging {
   val client = new GuardianContentClient(capiKey)
 
   case class PodcastInfo(
-    episodeWebUrl: String,
-    podcastName: String
+    episodeId: String,
+    podcastId: String
   )
 
   val cache = TrieMap[String, PodcastInfo]()
@@ -56,7 +56,7 @@ object PodcastLookup extends StrictLogging {
           case SuccessfulQuery(sr) => {
             for {
               result <- sr.results.headOption
-              podcastName <- result.tags.find(_.podcast.isDefined).map(_.webTitle)
+              podcastName <- result.tags.find(_.podcast.isDefined).map(_.webUrl)
             } yield {
               val podcastInfo = PodcastInfo(result.webUrl, podcastName)
               cache.put(filePath, podcastInfo)

--- a/src/main/scala/com/gu/contentapi/utils/Encoding.scala
+++ b/src/main/scala/com/gu/contentapi/utils/Encoding.scala
@@ -1,0 +1,18 @@
+package com.gu.contentapi.utils
+
+import java.net.URLEncoder
+
+object Encoding {
+
+  /* Similar output to js encodeURIComponent - see https://stackoverflow.com/a/611117*/
+  def encodeURIComponent(s: String) = {
+    URLEncoder.encode(s, "UTF-8")
+      .replaceAll("\\+", "%20")
+      .replaceAll("\\%21", "!")
+      .replaceAll("\\%27", "'")
+      .replaceAll("\\%28", "(")
+      .replaceAll("\\%29", ")")
+      .replaceAll("\\%7E", "~")
+  }
+}
+

--- a/src/test/scala/com/gu/contentapi/LambdaSpec.scala
+++ b/src/test/scala/com/gu/contentapi/LambdaSpec.scala
@@ -1,8 +1,9 @@
 package com.gu.contentapi
 
-import com.gu.contentapi.models.FastlyLog
+import com.gu.contentapi.models.{ Event, FastlyLog }
 import com.gu.contentapi.services.PodcastLookup
 import org.scalatest.{ FlatSpec, Matchers }
+
 import scala.io.Source
 
 class LambdaSpec extends FlatSpec with Matchers {
@@ -79,14 +80,59 @@ class LambdaSpec extends FlatSpec with Matchers {
     thirdPw should be(pageViews(2))
   }
 
-  // Commented out because we don't want to run CAPI query on TeamCity.
+
+  // TODO: the following tests should be treated as integration tests rather than being commented out
 
   //  it should "Test the Podcast Lookup function" in {
   //
   //    val info = PodcastLookup.getPodcastInfo("https://audio.guim.co.uk/2016/12/19-57926-FW-dec19-2016_mixdown.mp3")
   //
-  //    info.get.podcastName should be("Football Weekly - The Guardian")
-  //    info.get.episodeWebUrl should be("https://www.theguardian.com/football/blog/audio/2016/dec/19/manchester-city-bounce-back-to-leave-wenger-fuming-football-weekly")
+  //    info.get.podcastId should be("https://www.theguardian.com/football/series/footballweekly")
+  //    info.get.episodeId should be("https://www.theguardian.com/football/blog/audio/2016/dec/19/manchester-city-bounce-back-to-leave-wenger-fuming-football-weekly")
+  //  }
+  //
+  //  it should "Convert a fastly log to an Event ready to be sent to Ophan" in {
+  //
+  //    val log1 = FastlyLog(
+  //      time = "Fri, 11 Nov 2016 13:00:00 GMT",
+  //      request = "GET",
+  //      url = "/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
+  //      host = "composer-uploads-audio.s3-website-eu-west-1.amazonaws.com",
+  //      status = "206",
+  //      ipAddress = "66.87.114.159",
+  //      userAgent = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)",
+  //      referrer = "",
+  //      range = "bytes=6422528-",
+  //      headerBytesRead = "232",
+  //      bodyBytesRead = "0",
+  //      contentType = "audio/mp3",
+  //      age = "1592",
+  //      countryCode = "US",
+  //      region = "MI",
+  //      city = "Ypsilanti",
+  //      location = ""
+  //    )
+  //
+  //    Event(log1) should be(Some(Event(
+  //      viewId = "-5103960900567454554",
+  //      url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
+  //      ipAddress = "66.87.114.159",
+  //      episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
+  //      podcastId = "https://www.theguardian.com/football/series/footballweekly"
+  //    )))
+  //  }
+  //
+  //  it should "send a single podcast to Ophan" in {
+  //
+  //    val ev = Event(
+  //      viewId = "-5103960900567454554",
+  //      url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
+  //      ipAddress = "66.87.114.159",
+  //      episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
+  //      podcastId = "https://www.theguardian.com/football/series/footballweekly"
+  //    )
+  //
+  //    //    Ophan.send(ev)
   //  }
 
 }


### PR DESCRIPTION
- Transform `FastlyLog`s to `Event`s ready to be sent to Ophan
- Send the events 🎉 

I have a bunch of tests all commented out because they're making CAPI queries and Ophan requests, which we don't want to do every time we make a build, but they helped to make sure everything works as expected so is good to keep them there.