### PR TITLE
Send user agent information

### DIFF
--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -54,8 +54,9 @@ object Ophan {
     val IpAddress = Encoding.encodeURIComponent(event.ipAddress)
     val EpisodeId = Encoding.encodeURIComponent(event.episodeId)
     val PodcastId = Encoding.encodeURIComponent(event.podcastId)
+    val UserAgent = Encoding.encodeURIComponent(event.ua)
 
-    val url = s"$OphanUrl?url=$Url&viewId=${event.viewId}&isForwarded=true&ipAddress=$IpAddress&episodeId=$EpisodeId&podcastId=$PodcastId"
+    val url = s"$OphanUrl?url=$Url&viewId=${event.viewId}&isForwarded=true&ipAddress=$IpAddress&episodeId=$EpisodeId&podcastId=$PodcastId&ua=$UserAgent"
 
     val request = new Request.Builder().url(url).build()
 

--- a/src/main/scala/com/gu/contentapi/models/Event.scala
+++ b/src/main/scala/com/gu/contentapi/models/Event.scala
@@ -8,7 +8,8 @@ case class Event(
   url: String,
   ipAddress: String,
   episodeId: String,
-  podcastId: String
+  podcastId: String,
+  ua: String
 )
 
 object Event {
@@ -22,7 +23,8 @@ object Event {
         url = fullPathToFile,
         ipAddress = fastlyLog.ipAddress,
         episodeId = info.episodeId,
-        podcastId = info.podcastId
+        podcastId = info.podcastId,
+        ua = fastlyLog.userAgent
       )
     }
   }

--- a/src/test/scala/com/gu/contentapi/LambdaSpec.scala
+++ b/src/test/scala/com/gu/contentapi/LambdaSpec.scala
@@ -80,7 +80,6 @@ class LambdaSpec extends FlatSpec with Matchers {
     thirdPw should be(pageViews(2))
   }
 
-
   // TODO: the following tests should be treated as integration tests rather than being commented out
 
   //  it should "Test the Podcast Lookup function" in {
@@ -118,7 +117,8 @@ class LambdaSpec extends FlatSpec with Matchers {
   //      url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
   //      ipAddress = "66.87.114.159",
   //      episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
-  //      podcastId = "https://www.theguardian.com/football/series/footballweekly"
+  //      podcastId = "https://www.theguardian.com/football/series/footballweekly",
+  //      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)"
   //    )))
   //  }
   //
@@ -129,9 +129,9 @@ class LambdaSpec extends FlatSpec with Matchers {
   //      url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
   //      ipAddress = "66.87.114.159",
   //      episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
-  //      podcastId = "https://www.theguardian.com/football/series/footballweekly"
+  //      podcastId = "https://www.theguardian.com/football/series/footballweekly",
+  //      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)"
   //    )
-  //
   //    //    Ophan.send(ev)
   //  }
 


### PR DESCRIPTION
Send User Agent information to Ophan via a special queryParam `ua`.

This is handled in Ophan [here](https://github.com/guardian/ophan/blob/master/the-slab/app/extractors/PageViewExtractor.scala#L55-L58), and I wrote a test for it [here](https://github.com/guardian/ophan/blob/master/the-slab/test/extractors/PageViewExtractorTest.scala#L83-L113)

@mchv @shtukas 