### PR TITLE
Make viewId hash truly uniques

### DIFF
--- a/src/main/scala/com/gu/contentapi/models/Event.scala
+++ b/src/main/scala/com/gu/contentapi/models/Event.scala
@@ -25,7 +25,7 @@ object Event {
 
     PodcastLookup.getPodcastInfo(absoluteUrlToFile) map { info =>
       Event(
-        viewId = LongHashFunction.xx_r39().hashChars(absoluteUrlToFile + fastlyLog.time).toString,
+        viewId = LongHashFunction.xx_r39().hashChars(absoluteUrlToFile + fastlyLog.time + fastlyLog.ipAddress + fastlyLog.userAgent).toString,
         url = absoluteUrlToFile,
         ipAddress = fastlyLog.ipAddress,
         episodeId = info.episodeId,

--- a/src/test/scala/com/gu/contentapi/LambdaSpec.scala
+++ b/src/test/scala/com/gu/contentapi/LambdaSpec.scala
@@ -113,7 +113,7 @@ class LambdaSpec extends FlatSpec with Matchers with OptionValues {
   it should "Convert a fastly log to an event ready to be sent to Ophan" in {
 
     Event(log1) should be(Some(Event(
-      viewId = "-5103960900567454554",
+      viewId = "-1969270942156082233",
       url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
       ipAddress = "66.87.114.159",
       episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
@@ -127,7 +127,7 @@ class LambdaSpec extends FlatSpec with Matchers with OptionValues {
     val log2 = log1.copy(url = log1.url + "?platform=amazon-echo")
 
     Event(log2) should be(Some(Event(
-      viewId = "-5103960900567454554",
+      viewId = "-1969270942156082233",
       url = "https://audio.guim.co.uk/2016/11/10-58860-FW-10nov-2016_mixdown.mp3",
       ipAddress = "66.87.114.159",
       episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",


### PR DESCRIPTION
The log dates are to the nearest second so we want to factor in ip address and user agent to make sure the generated hash is unique.

@mchv @obrienm 