### PR TITLE
Filter head requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,5 +29,3 @@ riffRaffPackageType := (packageBin in Universal).value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"Off-platform::${name.value}"
-
-assemblySettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.9")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0") 
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.9")
 

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -40,7 +40,9 @@ class Lambda extends RequestHandler[S3Event, Unit] with StrictLogging {
         FastlyLog(line)
       }
 
-      val downloadsLogs = allFastlyLogs.filter(FastlyLog.onlyDownloads)
+      import com.gu.contentapi.utils.PredicateUtils._
+
+      val downloadsLogs = allFastlyLogs.filter(FastlyLog.onlyDownloads && FastlyLog.onlyGet)
 
       Ophan.send(downloadsLogs.flatMap(Event(_)))
     }
@@ -55,7 +57,7 @@ class Lambda extends RequestHandler[S3Event, Unit] with StrictLogging {
 
       import com.gu.contentapi.utils.PredicateUtils._
 
-      val downloadsLogs = allAcastLogs.filter(AcastLog.onlyDownloads && AcastLog.onlySuccessfulReponses)
+      val downloadsLogs = allAcastLogs.filter(AcastLog.onlyDownloads && AcastLog.onlySuccessfulReponses && AcastLog.onlyGet)
 
       Ophan.send(downloadsLogs.flatMap(Event(_)))
     }

--- a/src/main/scala/com/gu/contentapi/models/AcastLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/AcastLog.scala
@@ -63,7 +63,7 @@ If the viewer did not use an HTTP proxy or a load balancer, the value of x-forwa
 
 x-edge-result-type
 ------------------
-  
+
 How CloudFront classifies the response after the last byte left the edge location. In some cases, the result type can change between the time that CloudFront is ready to send the response and the time that CloudFront has finished sending the response. For example, in HTTP streaming, suppose CloudFront finds a segment in the edge cache. The value of x-edge-response-result-type, the result type immediately before CloudFront begins to respond to the request, is Hit. However, if the user closes the viewer before CloudFront has delivered the entire segment, the final result type—the value of x-edge-result-type—changes to Error.
 
 Possible values include:
@@ -115,7 +115,7 @@ continent code
 dma code
 postal_code
 longitude
-latitude 
+latitude
 
 */
 
@@ -144,8 +144,7 @@ case class AcastLog(
   postalCode: String,
   longitude: String,
   latitude: String,
-  filename: Option[String] = None
-)
+  filename: Option[String] = None)
 
 object AcastLog {
 

--- a/src/main/scala/com/gu/contentapi/models/AcastLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/AcastLog.scala
@@ -184,5 +184,8 @@ object AcastLog {
   /* filter out error reponses */
   val onlySuccessfulReponses: AcastLog => Boolean = { log => log.cloudfrontResponseResultType == "Hit" || log.cloudfrontResponseResultType == "RefreshHit" || log.cloudfrontResponseResultType == "Miss" }
 
+  /* filter out HEAD and any non GET requests */
+  val onlyGet: AcastLog => Boolean = { log => log.request == "GET" }
+
 }
 

--- a/src/main/scala/com/gu/contentapi/models/Event.scala
+++ b/src/main/scala/com/gu/contentapi/models/Event.scala
@@ -10,8 +10,7 @@ case class Event(
   episodeId: String,
   podcastId: String,
   ua: String,
-  platform: Option[String] = None
-)
+  platform: Option[String] = None)
 
 object Event {
 
@@ -31,8 +30,7 @@ object Event {
         episodeId = info.episodeId,
         podcastId = info.podcastId,
         ua = fastlyLog.userAgent,
-        platform = Option(parsedUrl.queryParameter("platform"))
-      )
+        platform = Option(parsedUrl.queryParameter("platform")))
     }
   }
 

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -46,5 +46,8 @@ object FastlyLog {
   /* filter out partial content requests */
   val onlyDownloads: FastlyLog => Boolean = { log => log.status != "206" }
 
+  /* filter out HEAD and any non GET requests */
+  val onlyGet: FastlyLog => Boolean = { log => log.request == "GET" }
+
 }
 

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -20,8 +20,7 @@ case class FastlyLog(
   countryCode: String,
   region: String,
   city: String,
-  location: String
-)
+  location: String)
 
 object FastlyLog {
 

--- a/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
@@ -23,8 +23,7 @@ object PodcastLookup extends StrictLogging {
   case class PodcastInfo(
     episodeId: String,
     podcastId: String,
-    absoluteUrl: Option[String] = None
-  )
+    absoluteUrl: Option[String] = None)
 
   val cache = TrieMap[String, PodcastInfo]()
   var cacheHits = 0
@@ -65,8 +64,7 @@ object PodcastLookup extends StrictLogging {
             }
           }
           case FailedQuery(err) => None
-        }, 2.seconds
-      )
+        }, 2.seconds)
     }
   }
 
@@ -111,8 +109,7 @@ object PodcastLookup extends StrictLogging {
             }
           }
           case FailedQuery(err) => None
-        }, 2.seconds
-      )
+        }, 2.seconds)
     }
   }
 

--- a/src/test/scala/com/gu/contentapi/AcastParsingSpec.scala
+++ b/src/test/scala/com/gu/contentapi/AcastParsingSpec.scala
@@ -42,8 +42,7 @@ class AcastParsingSpec extends FlatSpec with Matchers with OptionValues {
       postalCode = "DH9",
       longitude = "-1.7383",
       latitude = "54.8575",
-      filename = Some("https://audio.guim.co.uk/2017/05/26-52950-gdn.sci.20170526.gj.ancientgenomes.mp3")
-    )
+      filename = Some("https://audio.guim.co.uk/2017/05/26-52950-gdn.sci.20170526.gj.ancientgenomes.mp3"))
     downloads.head should be(first)
 
     val second = AcastLog(
@@ -71,8 +70,7 @@ class AcastParsingSpec extends FlatSpec with Matchers with OptionValues {
       postalCode = "00126",
       longitude = "12.4833",
       latitude = "41.9",
-      filename = Some("https://audio.guim.co.uk/2017/05/12-48386-gnl.rs.20170521.scienceweekly.alzheimers.mp3")
-    )
+      filename = Some("https://audio.guim.co.uk/2017/05/12-48386-gnl.rs.20170521.scienceweekly.alzheimers.mp3"))
     downloads(1) should be(second)
 
     val third = AcastLog(
@@ -100,8 +98,7 @@ class AcastParsingSpec extends FlatSpec with Matchers with OptionValues {
       postalCode = "6000",
       longitude = "115.8621",
       latitude = "-31.9674",
-      filename = Some("https://audio.guim.co.uk/2017/05/12-48386-gnl.rs.20170521.scienceweekly.alzheimers.mp3")
-    )
+      filename = Some("https://audio.guim.co.uk/2017/05/12-48386-gnl.rs.20170521.scienceweekly.alzheimers.mp3"))
     downloads(2) should be(third)
 
   }

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -67,6 +67,17 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
 
   }
 
+  it should "When converting a FastlyLog to an Event, it should filter out all the HEAD requests" in {
+
+    val fastlyLog2 = fastlyLog1.copy(request = "HEAD")
+
+    val logs: Seq[FastlyLog] = List(fastlyLog1, fastlyLog2)
+
+    val events = logs.filter(FastlyLog.onlyGet).flatMap(Event(_))
+
+    events.length should be(1)
+  }
+
   val acastLog1 = AcastLog(
     timestamp = "2017-05-18T07:18:00.000Z",
     bytes = "26940335",
@@ -140,6 +151,17 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       episodeId = "https://www.theguardian.com/science/audio/2017/may/28/the-bell-beaker-folk-science-weekly-podcast",
       podcastId = "https://www.theguardian.com/science/series/science",
       ua = "AppleCoreMedia/1.0.0.14E304 (iPhone; U; CPU OS 10_3_1 like Mac OS X; en_gb)")))
+  }
+
+  it should "When converting a AcastLog to an Event, it should filter out all the HEAD requests" in {
+
+    val acastLog3 = acastLog2.copy(request = "HEAD")
+
+    val logs: Seq[AcastLog] = List(acastLog1, acastLog2, acastLog3)
+
+    val events = logs.filter(AcastLog.onlyGet).flatMap(Event(_))
+
+    events.length should be(2)
   }
 
 }

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -24,8 +24,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     countryCode = "US",
     region = "MI",
     city = "Ypsilanti",
-    location = ""
-  )
+    location = "")
 
   it should "Convert a fastly log to an event ready to be sent to Ophan" in {
 
@@ -35,8 +34,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       ipAddress = "66.87.114.159",
       episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
       podcastId = "https://www.theguardian.com/football/series/footballweekly",
-      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)"
-    )))
+      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)")))
   }
 
   it should "Convert a fastly log and handling platform parameter correctly" in {
@@ -50,8 +48,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
       podcastId = "https://www.theguardian.com/football/series/footballweekly",
       ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)",
-      platform = Some("amazon-echo")
-    )))
+      platform = Some("amazon-echo"))))
   }
 
   it should "When converting a FastlyLog to an Event, it should filter out all the 206 partial content statuses" in {
@@ -94,8 +91,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     dmaCode = "0",
     postalCode = "00126",
     longitude = "12.4833",
-    latitude = "41.9"
-  )
+    latitude = "41.9")
 
   it should "Convert a acast log to an event ready to be sent to Ophan" in {
 
@@ -105,8 +101,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       ipAddress = "87.7.235.91",
       episodeId = "https://www.theguardian.com/science/audio/2017/may/14/science-weekly-can-we-cure-alzheimers-podcast",
       podcastId = "https://www.theguardian.com/science/series/science",
-      ua = "Mozilla/5.0 (Linux; U; en-us; BeyondPod 4)"
-    )))
+      ua = "Mozilla/5.0 (Linux; U; en-us; BeyondPod 4)")))
   }
 
   val acastLog2 = AcastLog(
@@ -134,8 +129,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     postalCode = "DH9",
     longitude = "-1.7383",
     latitude = "54.8575",
-    filename = Some("https://audio.guim.co.uk/2017/05/26-52950-gdn.sci.20170526.gj.ancientgenomes.mp3")
-  )
+    filename = Some("https://audio.guim.co.uk/2017/05/26-52950-gdn.sci.20170526.gj.ancientgenomes.mp3"))
 
   it should "Convert a acast log with a filename to an event ready to be sent to Ophan" in {
 
@@ -145,8 +139,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       ipAddress = "217.42.5.77",
       episodeId = "https://www.theguardian.com/science/audio/2017/may/28/the-bell-beaker-folk-science-weekly-podcast",
       podcastId = "https://www.theguardian.com/science/series/science",
-      ua = "AppleCoreMedia/1.0.0.14E304 (iPhone; U; CPU OS 10_3_1 like Mac OS X; en_gb)"
-    )))
+      ua = "AppleCoreMedia/1.0.0.14E304 (iPhone; U; CPU OS 10_3_1 like Mac OS X; en_gb)")))
   }
 
 }

--- a/src/test/scala/com/gu/contentapi/FastlyParsingSpec.scala
+++ b/src/test/scala/com/gu/contentapi/FastlyParsingSpec.scala
@@ -33,8 +33,7 @@ class FastlyParsingSpec extends FlatSpec with Matchers with OptionValues {
       countryCode = "US",
       region = "MI",
       city = "Ypsilanti",
-      location = ""
-    )
+      location = "")
     firstPw should be(pageViews.head)
 
     val secondPw = FastlyLog(
@@ -54,8 +53,7 @@ class FastlyParsingSpec extends FlatSpec with Matchers with OptionValues {
       countryCode = "IE",
       region = "07",
       city = "Dublin",
-      location = ""
-    )
+      location = "")
     secondPw should be(pageViews(1))
 
     val thirdPw = FastlyLog(
@@ -75,8 +73,7 @@ class FastlyParsingSpec extends FlatSpec with Matchers with OptionValues {
       countryCode = "GB",
       region = "A2",
       city = "Hendon",
-      location = ""
-    )
+      location = "")
     thirdPw should be(pageViews(2))
   }
 

--- a/src/test/scala/com/gu/contentapi/services/OphanSpec.scala
+++ b/src/test/scala/com/gu/contentapi/services/OphanSpec.scala
@@ -13,8 +13,7 @@ class OphanSpec extends FlatSpec with Matchers with OptionValues {
       ipAddress = "66.87.114.159",
       episodeId = "https://www.theguardian.com/football/audio/2016/nov/10/gordon-strachans-last-stand-with-scotland-football-weekly-extra",
       podcastId = "https://www.theguardian.com/football/series/footballweekly",
-      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)"
-    )
+      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)")
     //    Ophan.send(ev)
   }
 


### PR DESCRIPTION
3 commits to review separately:

-  0e4db31 update sbt-plugin dependencies to allow later to update to sbt `1.0.0` (currently blocked by [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact/pull/38))
- d9b862c update `scalariform` plugin and add code formatting change  
- a3226f5 only allow `GET` requests so drop `HEAD` requests, this will reduce number of downloads from `Podcast` user-agent  only from podcasts hosted on `fastly` 
 

 



