### PR TITLE
Do not exclude 206 response if byte range start with 0

### DIFF
--- a/src/main/scala/com/gu/contentapi/models/AcastLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/AcastLog.scala
@@ -178,8 +178,8 @@ object AcastLog {
     decodingMap.foldLeft(encoded) { case (cur, (from, to)) => cur.replaceAll(from, to) }
   }
 
-  /* filter out partial content requests */
-  val onlyDownloads: AcastLog => Boolean = { log => log.status != "206" }
+  /* filter out partial content requests that are not starting from 0 byte */
+  val onlyDownloads: AcastLog => Boolean = { log => log.status != "206" || log.range.startsWith("0-") }
 
   /* filter out error reponses */
   val onlySuccessfulReponses: AcastLog => Boolean = { log => log.cloudfrontResponseResultType == "Hit" || log.cloudfrontResponseResultType == "RefreshHit" || log.cloudfrontResponseResultType == "Miss" }

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -44,7 +44,7 @@ object FastlyLog {
   val cleanLog: String => Option[String] = removeFastlyFootprint _ andThen makeCsvLike andThen replaceNullElements
 
   /* filter out partial content requests */
-  val onlyDownloads: FastlyLog => Boolean = { log => log.status != "206" }
+  val onlyDownloads: FastlyLog => Boolean = { log => log.status != "206" || log.range.startsWith("bytes=0-") }
 
   /* filter out HEAD and any non GET requests */
   val onlyGet: FastlyLog => Boolean = { log => log.request == "GET" }

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -58,12 +58,13 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     val logsGrouped = logs.groupBy(f => f.status).mapValues(_.length)
 
     logsGrouped.get("206").value should be(71)
+
     logsGrouped.get("200").value should be(12)
     logsGrouped.get("304").value should be(3)
 
     val events = logs.filter(FastlyLog.onlyDownloads).flatMap(Event(_))
 
-    events.length should be(15)
+    events.length should be(41)
 
   }
 
@@ -162,6 +163,28 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     val events = logs.filter(AcastLog.onlyGet).flatMap(Event(_))
 
     events.length should be(2)
+  }
+
+  it should "When converting a AcastLog to an Event, it should not filter out  206 requests starting with 0" in {
+
+    val acastLog3 = acastLog1.copy(status = "206", range = "0-235")
+
+    val logs: Seq[AcastLog] = List(acastLog1, acastLog3)
+
+    val events = logs.filter(AcastLog.onlyDownloads).flatMap(Event(_))
+
+    events.length should be(2)
+  }
+
+  it should "When converting a AcastLog to an Event, it should  filter out  206 requests starting with a number higher than 0 " in {
+
+    val acastLog3 = acastLog1.copy(status = "206", range = "12-235")
+
+    val logs: Seq[AcastLog] = List(acastLog1, acastLog3)
+
+    val events = logs.filter(AcastLog.onlyDownloads).flatMap(Event(_))
+
+    events.length should be(1)
   }
 
 }


### PR DESCRIPTION
That should increase our downloads significantly when `acast` start sending us the data.
The implementation is based on the sample provided.

@oilnam 