### PR TITLE
Send bwid when sending events to Ophan

### DIFF
--- a/src/main/scala/com/gu/contentapi/services/Ophan.scala
+++ b/src/main/scala/com/gu/contentapi/services/Ophan.scala
@@ -1,8 +1,8 @@
 package com.gu.contentapi.services
 
-import okhttp3.{ OkHttpClient, Request }
+import okhttp3.{OkHttpClient, Request}
 import com.gu.contentapi.models.Event
-import com.gu.contentapi.utils.{ Encoding }
+import com.gu.contentapi.utils.Encoding
 
 object Ophan {
 
@@ -26,8 +26,9 @@ object Ophan {
     val PodcastId = Encoding.encodeURIComponent(event.podcastId)
     val UserAgent = Encoding.encodeURIComponent(event.ua)
     val Platform = event.platform.map(Encoding.encodeURIComponent)
+    val BrowserId = event.viewId + "-bwid"
 
-    val url = s"$OphanUrl?url=$Url&viewId=${event.viewId}&isForwarded=true&ipAddress=$IpAddress&episodeId=$EpisodeId&podcastId=$PodcastId&ua=$UserAgent" + Platform.map(p => "&platform=" + p).getOrElse("")
+    val url = s"$OphanUrl?url=$Url&viewId=${event.viewId}&bwid=$BrowserId&isForwarded=true&ipAddress=$IpAddress&episodeId=$EpisodeId&podcastId=$PodcastId&ua=$UserAgent" + Platform.map(p => "&platform=" + p).getOrElse("")
 
     val request = new Request.Builder().url(url).build()
 


### PR DESCRIPTION
- To Ophan, two events with the same `pageviewId` are considered the same event.
- In the Data Lake though, "uniqueness" is given by `(pageviewId, browserId)`.

The `browserId` is usually sourced by Ophan directly from the cookies, which we don't have in this case. If the cookie value isn't found, [Ophan will look for one in the queryparams](https://github.com/guardian/ophan/blob/master/tracker/app/lib/cookies.scala#L26); failing that, it will simply make one up randomly.

This means that if we send multiple events with the same `pageviewId` but without a `browserId`, they will be counted as one event in Ophan but multiple events in the Data Lake. Explicitly setting a `browserId` should fix this because all the events sent from this Lambda will have both *the same `pageviewId` and the same `browserId`.*

This explains why the numbers in Ophan don't match the one in the Data Lake. However, it does **NOT** explain why we're sending multiple events with the same `pageviewId` in the first place...

Final note: I'm slightly worried by[ this `isNew` field being set to `false`](https://github.com/guardian/ophan/blob/master/tracker/app/lib/cookies.scala#L27) when the `bwid` is explicitly set, but from my understanding it doesn't impact [how we compute regulars](https://github.com/guardian/ophan/blob/master/the-slab/app/lib/Loyalty.scala) anyway.


