### PR TITLE
Decode the URL of the filename otherwise it will double-encoded.

### DIFF
--- a/src/main/scala/com/gu/contentapi/models/Event.scala
+++ b/src/main/scala/com/gu/contentapi/models/Event.scala
@@ -22,7 +22,9 @@ object Event {
     val path = parsedUrl.encodedPath()
     val absoluteUrlToFile = hostUrl + path
 
-    PodcastLookup.getPodcastInfo(absoluteUrlToFile) map { info =>
+    val decodedUrl = java.net.URLDecoder.decode(absoluteUrlToFile, "UTF-8")
+
+    PodcastLookup.getPodcastInfo(decodedUrl) map { info =>
       Event(
         viewId = LongHashFunction.xx_r39().hashChars(absoluteUrlToFile + fastlyLog.time + fastlyLog.ipAddress + fastlyLog.userAgent).toString,
         url = absoluteUrlToFile,

--- a/src/main/scala/com/gu/contentapi/services/Ophan.scala
+++ b/src/main/scala/com/gu/contentapi/services/Ophan.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.services
 
-import okhttp3.{OkHttpClient, Request}
+import okhttp3.{ OkHttpClient, Request }
 import com.gu.contentapi.models.Event
 import com.gu.contentapi.utils.Encoding
 

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -51,6 +51,19 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
       platform = Some("amazon-echo"))))
   }
 
+  it should "Convert a fastly log whith empty space in filename" in {
+
+    val fastlyLog3 = fastlyLog1.copy(url = "/2018/01/09-50280-01 gnl.business.20180109.candb.goingglobal.mp3")
+
+    Event(fastlyLog3) should be(Some(Event(
+      viewId = "8813254641924280511",
+      url = "https://audio.guim.co.uk/2018/01/09-50280-01%20gnl.business.20180109.candb.goingglobal.mp3",
+      ipAddress = "66.87.114.159",
+      episodeId = "https://www.theguardian.com/small-business-network/audio/2018/jan/10/bedroom-business-to-world-domination-meet-the-mentors-with-trunkis-rob-law-podcast",
+      podcastId = "https://www.theguardian.com/business/series/the-business-podcast",
+      ua = "Samsung SM-G900P stagefright/Beyonce/1.1.9 (Linux;Android 6.0.1)")))
+  }
+
   it should "When converting a FastlyLog to an Event, it should filter out all the 206 partial content statuses" in {
 
     val logs: Seq[FastlyLog] = Source.fromFile("src/test/resources/logs-sample.txt")("ISO-8859-1").getLines().toSeq flatMap { line => FastlyLog(line) }


### PR DESCRIPTION
In #25 we thought the file reported was served by `acast` but it is in fact served by `fastly`. The `url` is not encoded in `fastly` logs, however we use `okhttp.encodedPath` method to retrieved the path with is returned encoded.

This is fine in general, but the Content API client will encode itself the `file` parameter, so we should `decode` the url before passing it to the client to query the Content API, otherwise the `file` parameter value is double-encoded preventing the podcast episode data to be retrieved.   