### PR TITLE
Exclude requests for byte range of 0-1

### DIFF
--- a/src/main/scala/com/gu/contentapi/models/AcastLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/AcastLog.scala
@@ -178,8 +178,8 @@ object AcastLog {
     decodingMap.foldLeft(encoded) { case (cur, (from, to)) => cur.replaceAll(from, to) }
   }
 
-  /* filter out partial content requests that are not starting from 0 byte */
-  val allowedRangePattern = """0-(?!1$)""".r
+  /* filter out partial content requests unless the byte-range starts from 0 and is not 0-1 */
+  val allowedRangePattern = """^0-(?!1$)""".r
   val onlyDownloads: AcastLog => Boolean = log =>
     log.status != "206" || allowedRangePattern.findFirstIn(log.range).nonEmpty
 

--- a/src/main/scala/com/gu/contentapi/models/AcastLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/AcastLog.scala
@@ -179,7 +179,9 @@ object AcastLog {
   }
 
   /* filter out partial content requests that are not starting from 0 byte */
-  val onlyDownloads: AcastLog => Boolean = { log => log.status != "206" || log.range.startsWith("0-") }
+  val allowedRangePattern = """0-(?!1$)""".r
+  val onlyDownloads: AcastLog => Boolean = log =>
+    log.status != "206" || allowedRangePattern.findFirstIn(log.range).nonEmpty
 
   /* filter out error reponses */
   val onlySuccessfulReponses: AcastLog => Boolean = { log => log.cloudfrontResponseResultType == "Hit" || log.cloudfrontResponseResultType == "RefreshHit" || log.cloudfrontResponseResultType == "Miss" }

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -44,7 +44,9 @@ object FastlyLog {
   val cleanLog: String => Option[String] = removeFastlyFootprint _ andThen makeCsvLike andThen replaceNullElements
 
   /* filter out partial content requests */
-  val onlyDownloads: FastlyLog => Boolean = { log => log.status != "206" || log.range.startsWith("bytes=0-") }
+  val allowedRangePattern = """bytes=0-(?!1$)""".r
+  val onlyDownloads: FastlyLog => Boolean = log =>
+    log.status != "206" || allowedRangePattern.findFirstIn(log.range).nonEmpty
 
   /* filter out HEAD and any non GET requests */
   val onlyGet: FastlyLog => Boolean = { log => log.request == "GET" }

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -43,8 +43,8 @@ object FastlyLog {
 
   val cleanLog: String => Option[String] = removeFastlyFootprint _ andThen makeCsvLike andThen replaceNullElements
 
-  /* filter out partial content requests */
-  val allowedRangePattern = """bytes=0-(?!1$)""".r
+  /* filter out partial content requests unless the byte-range starts from 0 and is not 0-1 */
+  val allowedRangePattern = """^bytes=0-(?!1$)""".r
   val onlyDownloads: FastlyLog => Boolean = log =>
     log.status != "206" || allowedRangePattern.findFirstIn(log.range).nonEmpty
 

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -191,7 +191,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     events.length should be(2)
   }
 
-  it should "When converting a AcastLog to an Event, it should not filter out  206 requests starting with 0 and not ending with 1" in {
+  it should "When converting a AcastLog to an Event, it should filter out 206 requests unless the byte-range starts from 0 and is not 0-1" in {
 
     val acastLog3 = acastLog1.copy(status = "206", range = "0-235")
     val acastLog4 = acastLog1.copy(status = "206", range = "0-1")

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -77,7 +77,7 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
 
     val events = logs.filter(FastlyLog.onlyDownloads).flatMap(Event(_))
 
-    events.length should be(41)
+    events.length should be(26)
 
   }
 
@@ -191,11 +191,12 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
     events.length should be(2)
   }
 
-  it should "When converting a AcastLog to an Event, it should not filter out  206 requests starting with 0" in {
+  it should "When converting a AcastLog to an Event, it should not filter out  206 requests starting with 0 and not ending with 1" in {
 
     val acastLog3 = acastLog1.copy(status = "206", range = "0-235")
+    val acastLog4 = acastLog1.copy(status = "206", range = "0-1")
 
-    val logs: Seq[AcastLog] = List(acastLog1, acastLog3)
+    val logs: Seq[AcastLog] = List(acastLog1, acastLog3, acastLog4)
 
     val events = logs.filter(AcastLog.onlyDownloads).flatMap(Event(_))
 

--- a/src/test/scala/com/gu/contentapi/EventSpec.scala
+++ b/src/test/scala/com/gu/contentapi/EventSpec.scala
@@ -193,14 +193,16 @@ class EventSpec extends FlatSpec with Matchers with OptionValues {
 
   it should "When converting a AcastLog to an Event, it should filter out 206 requests unless the byte-range starts from 0 and is not 0-1" in {
 
-    val acastLog3 = acastLog1.copy(status = "206", range = "0-235")
-    val acastLog4 = acastLog1.copy(status = "206", range = "0-1")
+    val acastLog3 = acastLog1.copy(status = "206", range = "0-10", userAgent = "acastLog3")
+    val acastLog4 = acastLog1.copy(status = "206", range = "0-11", userAgent = "acastLog4")
+    val acastLog5 = acastLog1.copy(status = "206", range = "0-1", userAgent = "acastLog5") //excluded
 
-    val logs: Seq[AcastLog] = List(acastLog1, acastLog3, acastLog4)
+    val logs: Seq[AcastLog] = List(acastLog1, acastLog3, acastLog4, acastLog5)
 
     val events = logs.filter(AcastLog.onlyDownloads).flatMap(Event(_))
 
-    events.length should be(2)
+    events.length should be(3)
+    events.map(_.ua) should be(Seq(acastLog1.userAgent, acastLog3.userAgent, acastLog4.userAgent))
   }
 
   it should "When converting a AcastLog to an Event, it should  filter out  206 requests starting with a number higher than 0 " in {


### PR DESCRIPTION
I'm investigating the cause of differing podcast counts in ophan vs data lake.

I suspect it's because this lambda is sometimes writing two events to kinesis with the same page_view_id, and data lake stores both but ophan's elasticsearch does not.
The reason for the duplicates is that iOS sends an initial request for bytes 0-1. They do this to check if byte-range requests are allowed, and to mess with our analytics.