### PR TITLE
Bump memory

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -64,7 +64,7 @@ Resources:
         Variables:
           CAPI_KEY: !Ref ContentApiKey
       Handler: com.gu.contentapi.Lambda::handleRequest
-      MemorySize: 256
+      MemorySize: 512
       Role:
         Fn::GetAtt:
         - RootRole

--- a/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
@@ -64,7 +64,7 @@ object PodcastLookup extends StrictLogging {
             }
           }
           case FailedQuery(err) => None
-        }, 2.seconds)
+        }, 5.seconds)
     }
   }
 


### PR DESCRIPTION
From the logs it seems the lambda has been having issues because:
1. it runs out of memory
2. some capi requests time out (it must make a lot of requests when the cache is empty)