### PR TITLE
Reduce runtime

### DIFF
--- a/src/main/scala/com/gu/contentapi/services/Ophan.scala
+++ b/src/main/scala/com/gu/contentapi/services/Ophan.scala
@@ -10,10 +10,12 @@ object Ophan extends Logging {
   private val client = new OkHttpClient()
   private val OphanUrl = "https://ophan.theguardian.com/i.gif"
 
+  private val eventsPerSecond = 30
+
   def send(events: Seq[Event]): Unit = {
-    events foreach { e =>
-      Thread.sleep(270000 / events.length) /* send events over a period of 4 minutes and 30 seconds */
-      Ophan.send(e)
+    events.grouped(eventsPerSecond) foreach { batch =>
+      Thread.sleep(1000)
+      batch.foreach(Ophan.send)
     }
 
     logger.info(s"Events sent to Ophan: ${events.length}")


### PR DESCRIPTION
[This change](https://github.com/guardian/podcasts-analytics-lambda/pull/9) made the lambda send events to ophan across 4mins 30secs, for rate limiting purposes.
This is very wasteful as the vast majority of log files have fewer than 10 events, but it always runs for nearly 5mins. The highest number of events I have found was 3655, so 30 per second should be plenty.

@mchv