### PR TITLE
Migrate to using gu-audio-logs bucket

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -46,6 +46,7 @@ Resources:
             - arn:aws:s3::*:fastly-logs-audio/*
             - arn:aws:s3::*:acast-logs-audio
             - arn:aws:s3::*:acast-logs-audio/*
+            - arn:aws:s3::*:gu-audio-logs/*
             Effect: Allow
   Lambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -7,4 +7,6 @@ object Config {
   val capiKey = sys.env("CAPI_KEY")
   val AcastAudioLogsBucketName = "acast-logs-audio"
 
+  val AudioLogsBucketName = "gu-audio-logs"
+
 }


### PR DESCRIPTION
Currently this lambda is triggered by events on the acast + fastly s3 buckets.
We're switching it to be triggered by the gu-audio-logs bucket, which [another lambda](https://github.com/guardian/s3-chunking-lambda) will be putting files into.

This change is backwards compatible - it will determine the log type (acast or fastly) by checking:
1. the bucket name (existing logic)
2. the prefix of the key, because each item key in gu-audio-logs will be prefixed with the name of the bucket it originated from