### PR TITLE
Increase response read timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.133",
   "com.amazonaws" % "aws-lambda-java-events" % "1.0.0",
   "com.github.melrief" %% "purecsv" % "0.1.1",
-  "com.gu" %% "content-api-client-default" % "12.0",
+  "com.gu" %% "content-api-client-default" % "17.1",
   "com.squareup.okhttp3" % "okhttp" % "3.10.0",
   "net.openhft" % "zero-allocation-hashing" % "0.6",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"

--- a/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
@@ -4,17 +4,17 @@ import java.util.concurrent.TimeUnit
 
 import com.gu.contentapi.client._
 import com.gu.contentapi.client.model.v1.SearchResponse
-import com.gu.contentapi.client.model.{ContentApiError, SearchQuery}
+import com.gu.contentapi.client.model.{ ContentApiError, SearchQuery }
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ Await, Future }
 import com.gu.contentapi.Config.capiKey
 import okhttp3.OkHttpClient
 import org.apache.logging.log4j.scala.Logging
 
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 object PodcastLookup extends Logging {
 

--- a/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
+++ b/src/main/scala/com/gu/contentapi/services/PodcastLookup.scala
@@ -1,17 +1,20 @@
 package com.gu.contentapi.services
 
+import java.util.concurrent.TimeUnit
+
 import com.gu.contentapi.client._
 import com.gu.contentapi.client.model.v1.SearchResponse
-import com.gu.contentapi.client.model.{ ContentApiError, SearchQuery }
+import com.gu.contentapi.client.model.{ContentApiError, SearchQuery}
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, ExecutionContext, Future}
 import com.gu.contentapi.Config.capiKey
+import okhttp3.OkHttpClient
 import org.apache.logging.log4j.scala.Logging
 
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 object PodcastLookup extends Logging {
 
@@ -21,7 +24,15 @@ object PodcastLookup extends Logging {
   case class SuccessfulQuery(searchResponse: SearchResponse) extends ResponseFromCapiQuery
   case class FailedQuery(errorMsg: String) extends ResponseFromCapiQuery
 
-  val client = new GuardianContentClient(capiKey)
+  val client = new GuardianContentClient(capiKey) {
+    override def httpClientBuilder: OkHttpClient.Builder = {
+      // CAPI requests sometimes fail due to java.net.SocketTimeoutException: timeout
+      // It is suspected this is due to response not being read in (default CAPI-client read timeout of) 2s.
+      // Since these requests are being executed in a lambda (and not in response to a client request),
+      // we can safely increase the read timeout.
+      super.httpClientBuilder.readTimeout(10, TimeUnit.SECONDS)
+    }
+  }
 
   case class PodcastInfo(
     episodeId: String,


### PR DESCRIPTION
In response to errors such as:
```
2020-05-10 16:05:10,800 <requestId> Thread-1 ERROR c.g.c.s.PodcastLookup$ - CAPI request repeatedly failed: timeout
java.net.SocketTimeoutException: timeout
at okio.Okio$4.newTimeoutException(Okio.java:232) ~[com.squareup.okio.okio-1.14.0.jar:?]
...
```
See in-line comments for more details.