### PR TITLE
Bump sbt and log4j deps versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, RiffRaffA
 
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.1",
-  "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.133",
   "com.amazonaws" % "aws-lambda-java-events" % "1.0.0",
@@ -21,12 +21,12 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 
-topLevelDirectory in Universal := None
-packageName in Universal := normalizedName.value
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value
 
 def env(key: String): Option[String] = Option(System.getenv(key))
 
-riffRaffPackageType := (packageBin in Universal).value
+riffRaffPackageType := (Universal / packageBin).value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"Off-platform::${name.value}"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.5.7


### PR DESCRIPTION
## What does this change?

Bump `sbt` to `1.5.7`
Bump `aws-lambda-java-log4j2` to `1.4.0`
Bump `log4j-api-scala` to `12.0`

The latter has a dependency on log4j 2.13.2 but this is evicted in favour of `2.16.0` brought in with `aws-lambda-java-log4j2` at `1.4.0`  

## How to test

Let's see if it'll compile first...

## How can we measure success?

TBA

## Have we considered potential risks?

We may stop sending podcast analytics to Ophan if this breaks. Or we may fail to recognise when there are problems with this service if the alarm fails to recognise logged errors.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
