### PR TITLE
retry S3 downloads

### DIFF
--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -17,8 +17,6 @@ class Lambda extends RequestHandler[S3Event, Unit] with Logging {
 
   override def handleRequest(event: S3Event, context: Context): Unit = {
 
-    logger.debug("PMR: 07/03/2023")
-
     val fastlyReportObjects = event.getRecords.asScala
       .filter(rec => isLogType(Config.FastlyAudioLogsBucketName, rec.getS3))
       .flatMap(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -17,6 +17,8 @@ class Lambda extends RequestHandler[S3Event, Unit] with Logging {
 
   override def handleRequest(event: S3Event, context: Context): Unit = {
 
+    logger.debug("PMR: 07/03/2023")
+
     val fastlyReportObjects = event.getRecords.asScala
       .filter(rec => isLogType(Config.FastlyAudioLogsBucketName, rec.getS3))
       .flatMap(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD

--- a/src/main/scala/com/gu/contentapi/services/S3.scala
+++ b/src/main/scala/com/gu/contentapi/services/S3.scala
@@ -9,17 +9,25 @@ import scala.util.{ Failure, Success, Try }
 
 object S3 extends Logging {
 
+  private val retryDelayMs = 100
+
   val client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
 
-  def downloadReport(bucketName: String, reportName: String): Option[S3Object] = {
+  def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Option[S3Object] = {
     Try(client.getObject(bucketName, reportName)) match {
       case Success(report) => {
         logger.info(s"Downloaded report $reportName")
         Some(report)
       }
       case Failure(e) => {
-        logger.warn(s"Failed to download $reportName - exception thrown $e")
-        None
+        if (retries > 0) {
+          logger.info(s"Failed to download $reportName - remaining retries: $retries - exception thrown $e")
+          Thread.sleep(retryDelayMs)
+          downloadReport(bucketName, reportName, retries - 1)
+        } else {
+          logger.warn(s"Failed to download $reportName - no retries left - exception thrown $e")
+          None
+        }
       }
     }
   }

--- a/src/main/scala/com/gu/contentapi/services/S3.scala
+++ b/src/main/scala/com/gu/contentapi/services/S3.scala
@@ -14,7 +14,7 @@ object S3 extends Logging {
   val client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
 
   def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Option[S3Object] = {
-    Try(client.getObject(bucketName, reportName)) match {
+    Try(client.getObject(bucketName, reportName + "XX")) match {
       case Success(report) => {
         logger.info(s"Downloaded report $reportName")
         Some(report)

--- a/src/main/scala/com/gu/contentapi/services/S3.scala
+++ b/src/main/scala/com/gu/contentapi/services/S3.scala
@@ -14,7 +14,7 @@ object S3 extends Logging {
   val client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
 
   def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Option[S3Object] = {
-    Try(client.getObject(bucketName, reportName + "XX")) match {
+    Try(client.getObject(bucketName, reportName)) match {
       case Success(report) => {
         logger.info(s"Downloaded report $reportName")
         Some(report)


### PR DESCRIPTION
## What does this change?

We have been intermittently getting some failures when running this Lambda, due to it being unable to dowload the podcast logs from S3. This seems to be a temporary blip, as the next time it runs it recovers, but in the meantime we have lost whatever analytics were contained therein.

```
WARN  c.g.c.s.S3$ - Failed to download fastly-logs-audio/2023-03-02T15:15:00.000-sDmhyhoTK05ZzPgxi01d.log - exception thrown com.amazonaws.services.s3.model.AmazonS3Exception: Service Unavailable (Service: Amazon S3; Status Code: 503; Error
 Code: 503 Service Unavailable; Request ID: 1A848907506CB3FE; Proxy: 
null), S3 Extended Request ID: 
bTjMCj/JkmV5OwRisnUpADy5XafAV6CCUloC/cmpMy9fSeV/i3PpmpqndrkPuLrtMQmDJWiKKLM9nTUyuy5NtzjL8NMwKQTD
```

This small change just makes it retry (3 times) before giving up.

## How to test

I deployed this on PROD and tested it - it runs every 5 minutes or so, and it didn't have any issues.

I also [intentionally triggered a failure](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fpodcasts-analytics-lambda-PROD-Lambda-UQMPL25PEG6O/log-events/2023$252F03$252F07$252F$255B$2524LATEST$255D13ff76097633427d99f5f5530aa3eb31$3Fstart$3DPT3H) by making it download the wrong filename, in order to test the retry logic, and it tried 3 times and gave up, as expected:

![image](https://user-images.githubusercontent.com/2242307/223507177-40b31618-9b59-4d48-9185-4e2d92dd0060.png)

## How can we measure success?

Reduced frequency of Alerts related to this lambda.

## Have we considered potential risks?

The change is small, but we should probably monitor the lambda executions for a while deploying to make sure they are running OK.