### PR TITLE
Increase Lambda memory allocation

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -71,7 +71,7 @@ Resources:
         Variables:
           CAPI_KEY: !Ref ContentApiKey
       Handler: com.gu.contentapi.Lambda::handleRequest
-      MemorySize: 320
+      MemorySize: 512
       Role:
         Fn::GetAtt:
         - RootRole


### PR DESCRIPTION
## What does this change?

bump up memory allocation on Lambda to fix "out of memory: metaspace" errors

## How to test

Deploy and monitor the "invokations/errors" graph for the lambda function. Success should be at 100% and failure at 0

## How can we measure success?

See above
