### PR TITLE
Repackage as a zip to avoid log4j errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           CAPI_KEY: ${{secrets.CAPI_KEY}}
           SBT_JUNIT_OUTPUT: ./junit-tests
-        run: sbt 'test;assembly'
+        run: sbt 'test;universal:packageBin'
 
 
       - uses: EnricoMi/publish-unit-test-result-action@v1
@@ -40,8 +40,6 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}
 
-      - run: cp target/scala-2.13/podcasts-analytics-lambda-assembly-0.1.0-SNAPSHOT.jar podcasts-analytics-lambda.jar
-
       - uses: guardian/actions-riff-raff@v2
         with:
           configPath: riff-raff.yaml
@@ -49,4 +47,4 @@ jobs:
           buildNumberOffset: 192
           contentDirectories: |
             podcasts-analytics-lambda:
-              - podcasts-analytics-lambda.jar
+              - target/universal/podcasts-analytics-lambda.zip

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,10 @@ scalaVersion  := "2.13.10"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:11", "-Xfatal-warnings")
 name := "podcasts-analytics-lambda"
 
+enablePlugins(JavaAppPackaging)
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value
+
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.2",
   "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
@@ -21,13 +25,5 @@ libraryDependencies ++= Seq(
 
 def env(key: String): Option[String] = Option(System.getenv(key))
 
-assembly / assemblyMergeStrategy := {
-  case "module-info.class"=>MergeStrategy.first
-  case PathList("META-INF","versions","9","module-info.class") => MergeStrategy.first
-  case PathList("META-INF","org","apache","logging","log4j","core","config","plugins","Log4j2Plugins.dat") => MergeStrategy.first
-  case x =>
-    val oldStrategy = (assembly / assemblyMergeStrategy).value
-    oldStrategy(x)
-}
 
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,10 +4,10 @@ deployments:
   podcasts-analytics-lambda:
     parameters:
       bucketSsmLookup: true
-      fileName: podcasts-analytics-lambda.jar
+      fileName: podcasts-analytics-lambda.zip
       functions:
         PROD:
-          filename: podcasts-analytics-lambda.jar
+          filename: podcasts-analytics-lambda.zip
           name: podcasts-analytics-lambda-PROD-Lambda-UQMPL25PEG6O
     type: aws-lambda
 regions:


### PR DESCRIPTION
## What does this change?

Package as a zip instead of a "fat jar".  The reason is, that in log4j2 all plugins carry a file called `Log4j2Plugins.dat`.  This is loaded by log4j2 at startup.  When you bundle as a jar, this file conflicts so you can only have 0 or 1 copies in the jar.  That results in the logger throwing errors at startup because it does not have the right config for the "lambda" logging plugin

## How to test

Build and deploy. You shouldn't see errors any more

## How can we measure success?

No spurious error alerts

## Have we considered potential risks?

n/a
