### PR TITLE
Update to actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       checks: write
       issues: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
@@ -34,16 +35,14 @@ jobs:
         if: always() #runs even if there is a test failure
         with:
           files: junit-tests/*.xml
-      - uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
           projectName: Off-platform::podcasts-analytics-lambda
           buildNumberOffset: 192
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             podcasts-analytics-lambda:
               - target/universal/podcasts-analytics-lambda.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build podcasts-analytics-lambda
 
 on:
   push:
-    branches: [ "**" ]
+    branches: ["**"]
   workflow_dispatch: {}
 
 jobs:
@@ -30,9 +30,8 @@ jobs:
           SBT_JUNIT_OUTPUT: ./junit-tests
         run: sbt 'test;universal:packageBin'
 
-
       - uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()  #runs even if there is a test failure
+        if: always() #runs even if there is a test failure
         with:
           files: junit-tests/*.xml
       - uses: aws-actions/configure-aws-credentials@v1-node16


### PR DESCRIPTION
Saw a recent email from DevX about upgrading, figured I’d do it quickly. Version 4 means we can get rid of the AWS credentials step and leaves us less vulnerable to credentials access by malicious dependencies

See [the release notes for version 4](https://github.com/guardian/actions-riff-raff/releases/tag/v4) and [those for version 3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0) (the latter necessary because we’re coming from version 2.)

(Have also committed auto-formatting done by my editor, hope that’s ok)