### PR TITLE
Move to AWS SDK v2 etc.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization  := "com.gu"
 description   := "AWS Lambda providing monitoring for podcasts consumption"
 scalacOptions += "-deprecation"
-scalaVersion  := "2.13.10"
+scalaVersion  := "2.13.14"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:11", "-Xfatal-warnings")
 name := "podcasts-analytics-lambda"
 
@@ -9,18 +9,21 @@ enablePlugins(JavaAppPackaging)
 Universal / topLevelDirectory := None
 Universal / packageName := normalizedName.value
 
+val awsVersion = "2.27.8"
+
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.2",
   "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.641",
-  "com.amazonaws" % "aws-lambda-java-events" % "3.11.1",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.6.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
+  "software.amazon.awssdk" % "s3" % awsVersion,
+  "software.amazon.awssdk" % "s3-transfer-manager" % awsVersion,
+  "com.amazonaws" % "aws-lambda-java-events" % "3.13.0",
   "io.kontainers" %% "purecsv" % "1.3.10",
-  "com.gu" %% "content-api-client-default" % "19.2.1",
+  "com.gu" %% "content-api-client-default" % "30.0.0",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
   "net.openhft" % "zero-allocation-hashing" % "0.6",
-  "org.scalatest" %% "scalatest" % "3.2.15" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.19" % "test"
 )
 
 def env(key: String): Option[String] = Option(System.getenv(key))

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -72,6 +72,8 @@ Resources:
           CAPI_KEY: !Ref ContentApiKey
       Handler: com.gu.contentapi.Lambda::handleRequest
       MemorySize: 512
+      EphemeralStorage:
+        Size: 1024  #Provision 1Gb of temp storage for downloads
       Role:
         Fn::GetAtt:
         - RootRole

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.2
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
+
+addDependencyTreePlugin

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -3,33 +3,42 @@ package com.gu.contentapi
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
 import com.amazonaws.services.lambda.runtime.{ Context, RequestHandler }
-import com.amazonaws.services.s3.model.S3Object
 
 import scala.jdk.CollectionConverters._
 import com.gu.contentapi.models.{ AcastLog, Event, FastlyLog }
-import com.gu.contentapi.services.{ Ophan, PodcastLookup, S3 }
-import com.amazonaws.util.IOUtils
-
-import scala.io.Source
+import com.gu.contentapi.services.{ Loader, Ophan, PodcastLookup, S3 }
 import org.apache.logging.log4j.scala.Logging
+import com.gu.contentapi.utils.PredicateUtils._
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import scala.concurrent.{ Await, Future }
+import scala.util.{ Failure, Success }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
 
 class Lambda extends RequestHandler[S3Event, Unit] with Logging {
 
   override def handleRequest(event: S3Event, context: Context): Unit = {
 
-    val fastlyReportObjects = event.getRecords.asScala
-      .filter(rec => isLogType(Config.FastlyAudioLogsBucketName, rec.getS3))
-      .flatMap(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD
-      .toList
+    val fastlyReportObjects = Await.result(
+      Future.sequence(
+        event.getRecords.asScala
+          .filter(rec => isLogType(Config.FastlyAudioLogsBucketName, rec.getS3))
+          .map(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD
+      ).map(_.toList),
+      Duration(context.getRemainingTimeInMillis, TimeUnit.MILLISECONDS))
 
-    val acastReportObjects = event.getRecords.asScala
-      .filter(rec => isLogType(Config.AcastAudioLogsBucketName, rec.getS3))
-      .flatMap(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD
-      .toList
+    handleReportsFromFastly(fastlyReportObjects.collect({ case Some(path) => path }))
 
-    handleReportsFromFastly(fastlyReportObjects)
+    val acastReportObjects = Await.result(
+      Future.sequence(
+        event.getRecords.asScala
+          .filter(rec => isLogType(Config.AcastAudioLogsBucketName, rec.getS3))
+          .map(rec => S3.downloadReport(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey.replaceAll("%3A", ":"))) // looks like the json object is not decoded properly by the SKD
+      ).map(_.toList),
+      Duration(context.getRemainingTimeInMillis, TimeUnit.MILLISECONDS))
 
-    handleReportsFromAcast(acastReportObjects)
+    handleReportsFromAcast(acastReportObjects.collect({ case Some(path) => path }))
 
     logger.debug(s"Cache hits: ${PodcastLookup.cacheHits}")
     logger.debug(s"Cache misses: ${PodcastLookup.cacheMisses}")
@@ -40,33 +49,30 @@ class Lambda extends RequestHandler[S3Event, Unit] with Logging {
     s3Entity.getBucket.getName == typeName ||
       s3Entity.getObject.getKey.startsWith(typeName)
 
-  private def handleReportsFromFastly(objects: List[S3Object]): Unit = {
+  private def handleReportsFromFastly(objects: List[Path]): Unit = {
     objects foreach { obj =>
+      Loader.linesFromFile(obj).map(_.flatMap(FastlyLog.apply)) match {
+        case Success(allFastlyLogs) =>
 
-      val allFastlyLogs = Source.fromBytes(IOUtils.toByteArray(obj.getObjectContent))("ISO-8859-1").getLines().toSeq flatMap { line =>
-        FastlyLog(line)
+          val downloadsLogs = allFastlyLogs.filter(FastlyLog.onlyDownloads && FastlyLog.onlyGet)
+          Ophan.send(downloadsLogs.flatMap(Event(_)))
+
+        case Failure(err) =>
+          logger.error(s"Could not load fastly logs from tempfile ${obj.toString}: ${err.getMessage}", err)
       }
-
-      import com.gu.contentapi.utils.PredicateUtils._
-
-      val downloadsLogs = allFastlyLogs.filter(FastlyLog.onlyDownloads && FastlyLog.onlyGet)
-
-      Ophan.send(downloadsLogs.flatMap(Event(_)))
     }
   }
 
-  private def handleReportsFromAcast(objects: List[S3Object]): Unit = {
+  private def handleReportsFromAcast(objects: List[Path]): Unit = {
     objects foreach { obj =>
+      Loader.linesFromFile(obj).map(_.flatMap(AcastLog.apply(_))) match {
+        case Success(allAcastLogs) =>
+          val downloadsLogs = allAcastLogs.filter(AcastLog.onlyDownloads && AcastLog.onlySuccessfulReponses && AcastLog.onlyGet)
 
-      val allAcastLogs = Source.fromBytes(IOUtils.toByteArray(obj.getObjectContent))("ISO-8859-1").getLines().toSeq flatMap { line =>
-        AcastLog(line)
+          Ophan.send(downloadsLogs.flatMap(Event(_)))
+        case Failure(err) =>
+          logger.error(s"Could not load acast logs from tempfile ${obj.toString}: ${err.getMessage}", err)
       }
-
-      import com.gu.contentapi.utils.PredicateUtils._
-
-      val downloadsLogs = allAcastLogs.filter(AcastLog.onlyDownloads && AcastLog.onlySuccessfulReponses && AcastLog.onlyGet)
-
-      Ophan.send(downloadsLogs.flatMap(Event(_)))
     }
   }
 

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -53,7 +53,7 @@ class Lambda extends RequestHandler[S3Event, Unit] with Logging {
     objects foreach { obj =>
       Loader.linesFromFile(obj).map(_.flatMap(FastlyLog.apply)) match {
         case Success(allFastlyLogs) =>
-
+          logger.debug(s"Fastly: processing ${obj.toString}")
           val downloadsLogs = allFastlyLogs.filter(FastlyLog.onlyDownloads && FastlyLog.onlyGet)
           Ophan.send(downloadsLogs.flatMap(Event(_)))
 
@@ -67,6 +67,7 @@ class Lambda extends RequestHandler[S3Event, Unit] with Logging {
     objects foreach { obj =>
       Loader.linesFromFile(obj).map(_.flatMap(AcastLog.apply(_))) match {
         case Success(allAcastLogs) =>
+          logger.debug(s"Acast: processing ${obj.toString}")
           val downloadsLogs = allAcastLogs.filter(AcastLog.onlyDownloads && AcastLog.onlySuccessfulReponses && AcastLog.onlyGet)
 
           Ophan.send(downloadsLogs.flatMap(Event(_)))

--- a/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
+++ b/src/main/scala/com/gu/contentapi/models/FastlyLog.scala
@@ -61,8 +61,7 @@ object FastlyLog extends Logging {
         cleanedFields(13),
         cleanedFields(14),
         cleanedFields(15),
-        cleanedFields(16)
-      )
+        cleanedFields(16))
     }
     triedLog.toEither.left.foreach { e =>
       logger.warn(s"Failed to parse line: '$withoutHeader': ${e.getMessage}", e)

--- a/src/main/scala/com/gu/contentapi/services/Loader.scala
+++ b/src/main/scala/com/gu/contentapi/services/Loader.scala
@@ -1,0 +1,18 @@
+package com.gu.contentapi.services
+
+import java.nio.charset.Charset
+import java.nio.file.{ Files, Path }
+import scala.io.{ Codec, Source }
+import scala.util.Try
+
+object Loader {
+  //Loads the tempfile into a set of lines and deletes it from the disk
+  def linesFromFile(path: Path): Try[Seq[String]] = {
+    implicit val codec: Codec = Codec.charset2codec(Charset.forName("ISO-8859-1"))
+    val s = Try { Source.fromFile(path.toFile) }
+    val content = s.flatMap(src => Try { src.getLines().toSeq })
+    s.map(_.close())
+    Files.deleteIfExists(path)
+    content
+  }
+}

--- a/src/main/scala/com/gu/contentapi/services/Ophan.scala
+++ b/src/main/scala/com/gu/contentapi/services/Ophan.scala
@@ -12,13 +12,14 @@ object Ophan extends Logging {
 
   private val eventsPerSecond = 30
 
-  def send(events: Seq[Event]): Unit = {
+  def send(events: Seq[Event]): Int = {
     events.grouped(eventsPerSecond) foreach { batch =>
       Thread.sleep(1000)
       batch.foreach(Ophan.send)
     }
 
     logger.info(s"Events sent to Ophan: ${events.length}")
+    events.length
   }
 
   private def send(event: Event): Unit = {

--- a/src/main/scala/com/gu/contentapi/services/S3.scala
+++ b/src/main/scala/com/gu/contentapi/services/S3.scala
@@ -1,35 +1,48 @@
 package com.gu.contentapi.services
 
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
-import com.amazonaws.services.s3.model.S3Object
 import org.apache.logging.log4j.scala.Logging
-
-import scala.util.{ Failure, Success, Try }
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.transfer.s3.S3TransferManager
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest
+import java.nio.file.{ Files, Path }
+import scala.jdk.FutureConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object S3 extends Logging {
 
   private val retryDelayMs = 100
 
-  val client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
+  private val client: S3AsyncClient = S3AsyncClient.builder().region(Region.EU_WEST_1).multipartEnabled(true).build()
+  private val transferManager: S3TransferManager = S3TransferManager.builder().s3Client(client).build()
 
-  def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Option[S3Object] = {
-    Try(client.getObject(bucketName, reportName)) match {
-      case Success(report) => {
-        logger.info(s"Downloaded report $reportName")
-        Some(report)
-      }
-      case Failure(e) => {
+  private def downloadToTemp(bucketName: String, reportName: String) = {
+    val tempFile = Files.createTempFile("fastly", ".txt")
+    val req = DownloadFileRequest.builder()
+      .getObjectRequest(GetObjectRequest.builder().bucket(bucketName).key(reportName).build())
+      .destination(tempFile)
+      .build()
+
+    val f = transferManager.downloadFile(req)
+    f.completionFuture().asScala.map(_ => tempFile)
+  }
+
+  def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Future[Option[Path]] = {
+    (for {
+      file <- downloadToTemp(bucketName, reportName)
+    } yield Some(file)).recoverWith({
+      case e: Throwable =>
         if (retries > 0) {
           logger.info(s"Failed to download $reportName - remaining retries: $retries - exception thrown $e")
           Thread.sleep(retryDelayMs)
           downloadReport(bucketName, reportName, retries - 1)
         } else {
           logger.warn(s"Failed to download $reportName - no retries left - exception thrown $e")
-          None
+          Future(None)
         }
-      }
-    }
+    })
   }
 
 }

--- a/src/main/scala/com/gu/contentapi/services/S3.scala
+++ b/src/main/scala/com/gu/contentapi/services/S3.scala
@@ -26,7 +26,10 @@ object S3 extends Logging {
       .build()
 
     val f = transferManager.downloadFile(req)
-    f.completionFuture().asScala.map(_ => tempFile)
+    f.completionFuture().asScala.map(_ => {
+      logger.info(s"Downloaded s3://$bucketName/$reportName")
+      tempFile
+    })
   }
 
   def downloadReport(bucketName: String, reportName: String, retries: Int = 3): Future[Option[Path]] = {

--- a/src/test/scala/com/gu/contentapi/FastlyParsingSpec.scala
+++ b/src/test/scala/com/gu/contentapi/FastlyParsingSpec.scala
@@ -35,7 +35,7 @@ class FastlyParsingSpec extends AnyFlatSpec with Matchers with OptionValues {
       region = "MI",
       city = "Ypsilanti",
       location = "")
-    pageViews.head should be (firstPw)
+    pageViews.head should be(firstPw)
 
     val secondPw = FastlyLog(
       time = "Fri, 11 Nov 2016 13:00:00 GMT",
@@ -78,13 +78,13 @@ class FastlyParsingSpec extends AnyFlatSpec with Matchers with OptionValues {
     thirdPw should be(pageViews(2))
   }
 
-    it should "parse lines containing double quotes" in {
-      val pageViews = Source.fromFile("src/test/resources/logs-with-poorly-escaped-doublequote-line.txt")("ISO-8859-1").getLines().toSeq flatMap { line =>
-        FastlyLog(line)
-      }
-
-      pageViews.length should be(1)
-      val lineWithDoubleQuote = pageViews.head
-      lineWithDoubleQuote.url shouldBe "/forum/index.php?SQ=0&t=search&srch=2WhWHlCyD3McfpRCsd4u0kgaYzV&btn_submit=Search&field=all&forum_limiter&attach=0&search_logic=AND&sort_order=REL&author=x\"+onmouseover%3Dalert%28document.domain%29+x%3D%22"
+  it should "parse lines containing double quotes" in {
+    val pageViews = Source.fromFile("src/test/resources/logs-with-poorly-escaped-doublequote-line.txt")("ISO-8859-1").getLines().toSeq flatMap { line =>
+      FastlyLog(line)
     }
+
+    pageViews.length should be(1)
+    val lineWithDoubleQuote = pageViews.head
+    lineWithDoubleQuote.url shouldBe "/forum/index.php?SQ=0&t=search&srch=2WhWHlCyD3McfpRCsd4u0kgaYzV&btn_submit=Search&field=all&forum_limiter&attach=0&search_logic=AND&sort_order=REL&author=x\"+onmouseover%3Dalert%28document.domain%29+x%3D%22"
   }
+}


### PR DESCRIPTION
## What does this change?

- Updates to AWS SDKv2, removing out-dated dependencies
- Uses the S3 Transfer library to simplify the code
- Drops files to ephemeral storage before parsing

## How to test

- Deploy it
- Monitor the logs and success/failure stats
- Be prepared to roll back!

## How can we measure success?

Less dependency aggro
