### PR TITLE
Remove access to unused paths in S3

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -46,12 +46,7 @@ Resources:
             - s3:Get*
             - s3:Delete*
             Resource:
-            - arn:aws:s3::*:content-api-config/*
             - arn:aws:s3::*:content-api-dist/*
-            - arn:aws:s3::*:fastly-logs-audio
-            - arn:aws:s3::*:fastly-logs-audio/*
-            - arn:aws:s3::*:acast-logs-audio
-            - arn:aws:s3::*:acast-logs-audio/*
             - arn:aws:s3::*:gu-audio-logs/*
             Effect: Allow
   Lambda:


### PR DESCRIPTION
## What does this change?

Removes access to unused paths in S3:
- https://github.com/guardian/podcasts-analytics-lambda/pull/36 moved us to `gu-audio-logs`, but left the old references for backwards compatibility. That was 2018 — the only trigger for the lambda now is `s3:ObjectCreated:*` in the `gu-audio-logs` bucket.
- There is no config file for `podcast-analytics-lambda` in the bucket `content-api-config/`.

## How to test

- Deploy. The lambda should log as usual.