### PR TITLE
Output logs in lambda-friendly format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.6.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
+  "org.apache.logging.log4j" % "log4j-layout-template-json" % "2.23.1",
   "software.amazon.awssdk" % "s3" % awsVersion,
   "software.amazon.awssdk" % "s3-transfer-manager" % awsVersion,
   "com.amazonaws" % "aws-lambda-java-events" % "3.13.0",

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val awsVersion = "2.27.8"
 
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.2",
-  "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
+  "org.apache.logging.log4j" %% "log4j-api-scala" % "13.1.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.6.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
   "org.apache.logging.log4j" % "log4j-layout-template-json" % "2.23.1",

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,8 +8,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.gu" level="debug"/>
-        <Root level="info">
+        <Root level="INFO">
             <AppenderRef ref="Lambda"/>
         </Root>
     </Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,9 +2,7 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
     <Appenders>
         <Lambda name="Lambda">
-            <LambdaJSONFormat>
-                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
-            </LambdaJSONFormat>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,11 +2,6 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
     <Appenders>
         <Lambda name="Lambda">
-            <LambdaTextFormat>
-                <PatternLayout>
-                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n </pattern>
-                </PatternLayout>
-            </LambdaTextFormat>
             <LambdaJSONFormat>
                 <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
             </LambdaJSONFormat>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,20 +2,14 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <!-- docs: https://logging.apache.org/log4j/2.x/manual/layouts.html#Patterns -->
-                <!-- this pattern prints:
-                     %date => 2012-11-02 14:34:02,123
-                     %X{AWSRequestId} => UUID (extracted from the MDC)
-                     %threadId => Thread-12345 (left-aligned, space-padded to 5 characters)
-                     %level => one of "FATAL", "ERROR", "WARN ", "INFO ", "DEBUG", "TRACE" (without the quotes)
-                              (left-aligned, padded to 5 characters)
-                     %logger => o.a.c.Foo
-                     %msg => the message being logged
-                     %n => newline character
-                -->
-                <pattern>%date %X{AWSRequestId} Thread-%-5threadId %-5level %logger{1.} - %msg%n</pattern>
-            </PatternLayout>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n </pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Outputs the application logs in a lambda-friendly format.

## How to test

Deploy to PROD, and keep an eye on [ELK.](https://logs.gutools.co.uk/s/content-platforms/app/r/s/KAtwi) You should see logs continue to arrive. They should now have a `level` property. Logs previous to the deploy do not have this property.

<img width="457" alt="Screenshot 2024-11-11 at 18 05 45" src="https://github.com/user-attachments/assets/fdafa941-c6a8-4d5c-a036-de9818c6f8e8">

🎉 