### PR TITLE
Squelch alarms for 'leak' log errors from Netty, but keep logging them

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -129,7 +129,7 @@ Resources:
         - MetricValue: 1
           MetricNamespace: content-api/podcasts-analytics-lambda
           MetricName: LogErrors
-  LambdaLogErrorWarnMetricFilter:
+  LambdaLogErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       FilterPattern: "ERROR -ResourceLeakDetector"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -138,7 +138,7 @@ Resources:
         - MetricValue: 1
           MetricNamespace: content-api/podcasts-analytics-lambda
           MetricName: LogErrors
-  LambdaLogFatalWarnMetricFilter:
+  LambdaLogFatalMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       FilterPattern: "FATAL -ResourceLeakDetector"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -117,12 +117,31 @@ Resources:
       TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmSnsTopic
-  LambdaLogErrorsMetricFilter:
+  # Alarm on WARN, ERROR and FATAL metrics.
+  # -ResourceLeakDetector to ensure we do not alarm on unavoidable and seemingly
+  # harmless error messages from Netty - see https://github.com/aws/aws-sdk-java-v2/issues/4654
+  LambdaLogWarnMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      # -ResourceLeakDetector to ensure we do not alarm on unavoidable and seemingly
-      # harmless error messages from Netty - see https://github.com/aws/aws-sdk-java-v2/issues/4654
-      FilterPattern: "?FATAL ?ERROR ?WARN -\"i.n.u.ResourceLeakDetector\""
+      FilterPattern: "WARN -ResourceLeakDetector"
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}"
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: content-api/podcasts-analytics-lambda
+          MetricName: LogErrors
+  LambdaLogErrorWarnMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: "ERROR -ResourceLeakDetector"
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}"
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: content-api/podcasts-analytics-lambda
+          MetricName: LogErrors
+  LambdaLogFatalWarnMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: "FATAL -ResourceLeakDetector"
       LogGroupName: !Sub "/aws/lambda/${FunctionName}"
       MetricTransformations:
         - MetricValue: 1

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -120,7 +120,9 @@ Resources:
   LambdaLogErrorsMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterPattern: "?FATAL ?ERROR ?WARN"
+      # -ResourceLeakDetector to ensure we do not alarm on unavoidable and seemingly
+      # harmless error messages from Netty - see https://github.com/aws/aws-sdk-java-v2/issues/4654
+      FilterPattern: "?FATAL ?ERROR ?WARN -ResourceLeakDetector"
       LogGroupName: !Sub "/aws/lambda/${FunctionName}"
       MetricTransformations:
         - MetricValue: 1

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -122,7 +122,7 @@ Resources:
     Properties:
       # -ResourceLeakDetector to ensure we do not alarm on unavoidable and seemingly
       # harmless error messages from Netty - see https://github.com/aws/aws-sdk-java-v2/issues/4654
-      FilterPattern: "?FATAL ?ERROR ?WARN -ResourceLeakDetector"
+      FilterPattern: "?FATAL ?ERROR ?WARN -\"i.n.u.ResourceLeakDetector\""
       LogGroupName: !Sub "/aws/lambda/${FunctionName}"
       MetricTransformations:
         - MetricValue: 1

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.Duration
 class Lambda extends RequestHandler[S3Event, Unit] with Logging {
 
   override def handleRequest(event: S3Event, context: Context): Unit = {
-
+    logger.error("ERROR i.n.u.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. <THIS ERROR IS A TEST LOG LINE, PLEASE IGNORE>")
     val fastlyReportObjects = Await.result(
       Future.sequence(
         event.getRecords.asScala

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.Duration
 class Lambda extends RequestHandler[S3Event, Unit] with Logging {
 
   override def handleRequest(event: S3Event, context: Context): Unit = {
-    logger.error("ERROR i.n.u.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. <THIS ERROR IS A TEST LOG LINE, PLEASE IGNORE>")
+
     val fastlyReportObjects = Await.result(
       Future.sequence(
         event.getRecords.asScala


### PR DESCRIPTION
## What does this change?

Prevent us from firing alarms for 'leak' log errors from Netty, but keep logging them, in case they're important in future.

They relate to a bug in AWS-SDK that is both unfixed and (seemingly) benign. Other users have not reported problems as a result of them appearing, and given that this is lambda code, leaks are perhaps less problematic in a short-lived application.

<details><summary>Errors look like this.</summary>

```
ERROR i.n.u.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html  for more information. Recent access records: Created at: io.netty.buffer.UnpooledByteBufAllocator.newDirectBuffer(UnpooledByteBufAllocator.java:96) 
    io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188) 
    io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:179) 
    io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:116) 
    io.netty.handler.ssl.SslHandler.allocate(SslHandler.java:2362) 
    io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1438) 
    io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1336) 
    io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1385) 
    io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530) 
    io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469) 
    io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) 
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) 
    io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) 
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) 
    io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) 
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) 
    io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918) 
    io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) 
    io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) 
    io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) 
    io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) 
    io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) 
    io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994) 
    io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) 
    java.base/java.lang.Thread.run(Unknown Source)
```

</details>

## Implementation details

AFAICS, in order to prevent these log lines contributing to our metric, we must create three filters, one for each of the `WARN|ERROR|FATAL` log lines we'd like to alarm on, plus the text we'd like to ignore. This is because the AWS metrics filter does not support arbitrary boolean logic or grouping, and prevents users from combining optional fields with negating fields [(docs)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#:~:text=unstructured%20log%20events-,Match%20terms%20in%20unstructured%20log%20events,-Using%20filter%20patterns):

> You cannot combine the question mark ("?") with other filter patterns, such as include and exclude terms. If you combine "?" with other filter patterns, the question mark ("?") will be ignored.

In other words, I don't think we can't write something like `(WARNING|ERROR|FATAL) && -ResourceLeakDetector`. (I'd love to be wrong, please let me know!)

## How to test

- Unrevert commit d407072f81a9c32e887a5c50434cd657e5d0641c and deploy to PROD to have the lambda continually log an error containing our excluded error message.
- Note the alarm ⏰
- Deploy the CFN template in this project.
- The alarm should resolve.

Tested in PROD, all looks good!

<img width="853" alt="Screenshot 2024-11-12 at 14 52 55" src="https://github.com/user-attachments/assets/d48a678d-4db7-4a77-a792-d1562c0caac6">